### PR TITLE
Fix Django setup to make it work with 1.6 / 1.7

### DIFF
--- a/testsite/tornado_main.py
+++ b/testsite/tornado_main.py
@@ -12,6 +12,7 @@ import tornado.httpserver
 import tornado.ioloop
 import tornado.web
 import tornado.wsgi
+django.setup()
 
 define('port', type=int, default=8080)
 


### PR DESCRIPTION
You need to call django.setup() to finish the Django initialization, otherwise it fails with all sorts of errors for me (Django 1.6 & 1.7).